### PR TITLE
- Unify naming for a unique lxqt. No more suffixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 find_package(Qt5Widgets REQUIRED QUIET)
 find_package(Qt5LinguistTools REQUIRED QUIET)
 
-find_package(lxqt-qt5 REQUIRED QUIET)
+find_package(lxqt REQUIRED QUIET)
 
 include(${LXQT_USE_FILE})
 


### PR DESCRIPTION
Signed-off-by: Helio Chissini de Castro helio@kde.org
