### PR TITLE
Don't use automatic string conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,16 @@ add_executable(lxqt-openssh-askpass
     ${QM_FILES}
     ${lxqt-openssh_QM_LOADER}
 )
+
+target_compile_definitions(lxqt-openssh-askpass
+    PRIVATE
+        "QT_USE_QSTRINGBUILDER"
+        "QT_NO_CAST_FROM_ASCII"
+        "QT_NO_CAST_TO_ASCII"
+        "QT_NO_URL_CAST_FROM_STRING"
+        "QT_NO_CAST_FROM_BYTEARRAY"
+)
+
 target_link_libraries(lxqt-openssh-askpass
     Qt5::Widgets
     lxqt

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -44,7 +44,7 @@ MainWindow::~MainWindow()
 
 void MainWindow::accept()
 {
-    puts(passwordEdit->text().toUtf8());
+    puts(passwordEdit->text().toUtf8().constData());
     qApp->exit(0);
 }
 


### PR DESCRIPTION
* Disables automatic conversions from 8-bit strings (char *) to unicode
  QStrings.
* Disables automatic conversion from QString to 8-bit strings (char *).
* Disables automatic conversions from QByteArray to const char * or const
  void *.
* Disables automatic conversions from QString (or char *) to QUrl.
* Use QStringBuilder for more efficient string creation.

It make us aware of string and encoding conversions.