### PR TITLE
Support OpenSSH askpass prompt modes

### DIFF
--- a/man/lxqt-openssh-askpass.1
+++ b/man/lxqt-openssh-askpass.1
@@ -3,7 +3,7 @@
 lxqt-openssh-askpass \- Password access over ssh module of \fBLXQt\fR: the faster and lighter Qt Desktop Environment
 .SH SYNOPSIS
 .B lxqt-openssh-askpass
-[\fICurrently No command line arguments\fR]
+[\fIprompt\fR]
 .br
 .SH DESCRIPTION
 This module handles openssh security password access for \fBLXQt\fR. The openssh askpass module, will perform 
@@ -32,6 +32,15 @@ Manager.
 .SH BEHAVIOR
 The module detected on shares privilege access, and maintains a security dialog
 that asks for the user's key needed for access over another machine host.
+.P
+If exactly one non-option argument is provided, it is displayed as the prompt
+text. Otherwise, a default prompt is used.
+.P
+If the environment variable \fBSSH_ASKPASS_PROMPT\fR is set to \fIconfirm\fR,
+the module shows a yes-or-no prompt, defaulting to yes, and prints \fIyes\fR
+when accepted. If it is set to \fInone\fR, the module shows the prompt with only
+a close button. Otherwise, it shows the usual OK-or-cancel passphrase prompt,
+defaulting to OK. This variable is typically set by \fBssh-add\fR(1).
 .P
 This module is very early stage, and not enabled by default, so you must added an env
 by the \fBlxqt\-settings\fR application as \fISSH_ASKPASS=\fR 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@
 
 #include "mainwindow.h"
 
+constexpr const char *PROMPT_TYPE_ENV_VAR = "SSH_ASKPASS_PROMPT";
 
 int main(int argc, char *argv[])
 {
@@ -45,14 +46,21 @@ int main(int argc, char *argv[])
     parser.addHelpOption();
     parser.process(a);
 
-    // TODO/FIXME: maybe a better algorithm?
-    QString prompt;
-    if (a.arguments().count() < 2)
-        prompt = QObject::tr("unknown request");
-    else
-        prompt = a.arguments().at(a.arguments().count()-1);
+    QString prompt = QObject::tr("unknown request");
+    const QStringList arguments = parser.positionalArguments();
+    if (arguments.count() == 1) {
+        prompt = arguments.at(0);
+    }
 
-    MainWindow w(prompt);
+    PromptType promptType = PromptType::Entry;
+    const QString promptTypeString = qEnvironmentVariable(PROMPT_TYPE_ENV_VAR);
+    if (promptTypeString == QLatin1String("confirm")) {
+        promptType = PromptType::Confirm;
+    } else if (promptTypeString == QLatin1String("none")) {
+        promptType = PromptType::None;
+    }
+
+    MainWindow w(prompt, promptType);
     w.show();
 
     return a.exec();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -26,17 +26,45 @@
  * END_COMMON_COPYRIGHT_HEADER */
 
 #include <stdio.h>
+#include <QPushButton>
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 
 
-MainWindow::MainWindow(const QString &prompt, QWidget *parent)
+MainWindow::MainWindow(const QString &prompt, PromptType promptType, QWidget *parent)
     : QDialog(parent)
+    , promptType_(promptType)
 {
     setWindowFlags(Qt::WindowStaysOnTopHint);
     setupUi(this);
     promptLabel->setText(prompt);
-    passwordEdit->setFocus(); // needed with Qt >= 6.6.1
+
+    switch (promptType_) {
+    case PromptType::Entry:
+        if (QPushButton *okButton = buttonBox->button(QDialogButtonBox::Ok)) {
+            okButton->setDefault(true);
+        }
+        passwordEdit->setFocus(); // needed with Qt >= 6.6.1
+        break;
+    case PromptType::Confirm:
+        label->hide();
+        passwordEdit->hide();
+        buttonBox->setStandardButtons(QDialogButtonBox::Yes | QDialogButtonBox::No);
+        if (QPushButton *yesButton = buttonBox->button(QDialogButtonBox::Yes)) {
+            yesButton->setDefault(true);
+        }
+        break;
+    case PromptType::None:
+        label->hide();
+        passwordEdit->hide();
+        buttonBox->setStandardButtons(QDialogButtonBox::Close);
+        if (QPushButton *closeButton = buttonBox->button(QDialogButtonBox::Close)) {
+            closeButton->setDefault(true);
+        }
+        break;
+    }
+
+    adjustSize();
 }
 
 MainWindow::~MainWindow()
@@ -45,7 +73,18 @@ MainWindow::~MainWindow()
 
 void MainWindow::accept()
 {
-    puts(passwordEdit->text().toUtf8().constData());
+    switch (promptType_) {
+    case PromptType::Confirm:
+        puts("yes");
+        break;
+    case PromptType::Entry:
+        puts(passwordEdit->text().toUtf8().constData());
+        break;
+    case PromptType::None:
+        qApp->exit(1);
+        return;
+    }
+
     qApp->exit(0);
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -31,18 +31,26 @@
 #include <QDialog>
 #include "ui_mainwindow.h"
 
+enum class PromptType {
+    Entry,
+    Confirm,
+    None
+};
 
 class MainWindow : public QDialog, public Ui::MainWindow
 {
     Q_OBJECT
 
 public:
-    explicit MainWindow(const QString &prompt, QWidget *parent = 0);
+    explicit MainWindow(const QString &prompt, PromptType promptType, QWidget *parent = 0);
     ~MainWindow();
 
 public slots:
     void accept();
     void reject();
+
+private:
+    PromptType promptType_;
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
Adds support for OpenSSH's `SSH_ASKPASS_PROMPT` hint and makes prompt argument handling match the classic `ssh-askpass(1)` contract, enabling  `lxqt-openssh-askpass` handle the three prompt modes used by OpenSSH:

- Normal entry prompts: show the existing passphrase dialog and print the entered text.
- `SSH_ASKPASS_PROMPT=confirm`: show a yes/no confirmation dialog and print `yes` when accepted.
- `SSH_ASKPASS_PROMPT=none`: show a notification-style dialog with only a close button and return failure.

The command-line prompt text is now taken only from exactly one non-option argument. If there are no prompt arguments, or more than one, the default prompt is used.

## Contract

OpenSSH invokes askpass helpers with the prompt text as a single argument:

- https://github.com/openssh/openssh-portable/blob/66847768ffd5a2a004891c8d3bd79eaba12625b7/readpass.c#L77
- https://github.com/openssh/openssh-portable/blob/66847768ffd5a2a004891c8d3bd79eaba12625b7/readpass.c#L280

For normal `ssh-add(1)` passphrase prompts, OpenSSH passes only that prompt argument. For confirmation prompts, OpenSSH also sets `SSH_ASKPASS_PROMPT=confirm`. For notification-only prompts, OpenSSH sets `SSH_ASKPASS_PROMPT=none`. The prompt text still comes from the argument vector in all three cases; the environment variable only selects the kind of UI.

## Compatibility

Classic X11 `ssh-askpass` uses custom prompt text only when exactly one non-option argument is provided. This change follows that behavior:

- No arguments: use default prompt
- One argument: use that argument as prompt text
- One empty argument: show no prompt text
- More than one argument: use default prompt

This differs from the previous LXQt behavior, which used the last raw application argument whenever any argument was provided. The behavior in this PR intentionally follows classic X11 `ssh-askpass` for compatibility:

- `lxqt-openssh-askpass "Prompt text"` still shows `Prompt text`.
- `lxqt-openssh-askpass "one" "two"` now shows the default prompt instead of `two`.
- `SSH_ASKPASS_PROMPT=confirm lxqt-openssh-askpass "Continue?"` now shows a confirmation prompt and prints `yes` on acceptance.
- `SSH_ASKPASS_PROMPT=none lxqt-openssh-askpass "Touch your security key"` now shows a close-only prompt and exits nonzero.

## Testing Done

Built successfully with:

```sh
cmake -S . -B build
cmake --build build
```

Manual test commands:

```sh
./build/lxqt-openssh-askpass "Enter test passphrase:"
./build/lxqt-openssh-askpass "one" "two"
SSH_ASKPASS_PROMPT=confirm ./build/lxqt-openssh-askpass "Continue?"
SSH_ASKPASS_PROMPT=none ./build/lxqt-openssh-askpass "Touch your security key"
```

Fixes #88
Closes lxqt/lxqt-sudo#202